### PR TITLE
:zap: Add endpoint method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ const $axios = axios.create({
   baseURL,
 });
 
-let q = new StrapiQuery()
+let queryString = new StrapiQuery()
+  .endpoint('api/offers')
   .state("live")
   .fields("title")
   .populate("categories")
@@ -26,9 +27,10 @@ let q = new StrapiQuery()
   // render query string
   .get();
 
-console.log(q);
+console.log(queryString);
+// api/offers?filters[$and][0][categories][slug][$in][0]=teste&filters[$and][0][categories][slug][$in][1]=alimentacao&filters[$or][0][title][$endsWith][0]=mia&publicationState=live&fields[0]=title&populate[0]=categories&sort[0]=title%3Adesc&pagination[page]=1&pagination[pageSize]=25&pagination[withCount]=true
 
-$axios.get(`api/offers?${q}`).then((response) => {
+$axios.get(q).then((response) => {
   console.log(response.data.data);
 });
 ```

--- a/index.js
+++ b/index.js
@@ -1,14 +1,27 @@
 const qs = require("qs");
 
-class StrapiQuery {
+export class StrapiQuery {
   constructor() {
     this.tmpFilter = {}; //store the condition
-    this.tmpObject = {};
-    this.tmpKey = {};
+    this.tmpObject = {}; //store the object
+    this.tmpKey = {}; //store the key
+    this.base = ""; //store the base url
     this.query = {
       filters: {},
-    };
+    }; //store the query
   }
+
+  /**
+   * Set the base endpoint for the query.
+   *
+   * @param {string} endpointPath The base URL to be set .
+   * @returns {this}
+   */
+  endpoint(endpointPath) {
+    this.endpoint = endpointPath;
+    return this;
+  }
+
   /**
    * Queries can accept a `fields` parameter to select only some fields. By default, only the following types of fields are returned:
    *
@@ -74,16 +87,20 @@ class StrapiQuery {
     this.query.sort = fields;
     return this;
   }
+
   #condition(key = "$and", path) {
     if (!this.query.filters[key]) {
       this.query.filters[key] = [];
     }
     this.#clearFilters();
+
     this.tmpFilter = this.query.filters[key];
     let last = this.tmpObject;
     for (let index = 0; index < path.length; index++) {
       const element = path[index];
+
       last[element] = {};
+
       last = last[element];
     }
     this.tmpKey = last;
@@ -120,6 +137,7 @@ class StrapiQuery {
     if (!this.query.pagination) {
       this.query.pagination = {};
     }
+
     this.query.pagination = {
       page,
       pageSize,
@@ -139,6 +157,7 @@ class StrapiQuery {
     if (!this.query.pagination) {
       this.query.pagination = {};
     }
+
     this.query.pagination = {
       start,
       limit,
@@ -146,8 +165,10 @@ class StrapiQuery {
     };
     return this;
   }
+
   #filter(key = "$eq", fields) {
     this.tmpKey[key] = fields;
+
     this.tmpFilter.push(this.tmpObject);
     this.#clearFilters();
     return this;
@@ -343,9 +364,10 @@ class StrapiQuery {
    * @returns {string}
    */
   get() {
-    return qs.stringify(this.query, {
+    const queryString = qs.stringify(this.query, {
       encodeValuesOnly: true, // prettify URL
     });
+    return `${this.endpoint}?${queryString}`;
   }
 }
 


### PR DESCRIPTION
# Description

To simplify the usage and avoid manual concatenation of URL strings, i enhance the implementation by adding an endpoint() method. This method allows you to specify the endpoint directly. 
This improvement streamlines the process and enhances the clarity of the code.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules